### PR TITLE
fix(colors): make whitespace chars visible

### DIFF
--- a/themes/kanagawa-color-theme.json
+++ b/themes/kanagawa-color-theme.json
@@ -68,7 +68,7 @@
         "editorSuggestWidget.border": "#223249",
         "editorSuggestWidget.selectedBackground": "#2D4F67",
         "editorWarning.foreground": "#FF9E3B",
-        "editorWhitespace.foreground": "#1F1F28",
+        "editorWhitespace.foreground": "#3E3E51",
         "editorWidget.background": "#1f1f28",
         "focusBorder": "#223249",
         "gitDecoration.ignoredResourceForeground": "#727169",


### PR DESCRIPTION
Due to the color of whitespace characters (spaces and tabs) is same as the background color (`#1F1F28`), they are not visible unless being highlighted at the current line even if `editor.renderWhitespace` is not `none`.

<img width="136" alt="Screen Shot 2022-12-19 at 10 48 53" src="https://user-images.githubusercontent.com/3948302/208334405-bbb8d823-0d12-4a7a-8b99-f8795423ec6b.png">

So I changed `editorWhitespace.foreground` to be slightly lighter than  `editorIndentGuide.activeBackground` `#363646` but darker than  
`editorLineNumber.foreground` `#54546D`.

This is the result:
<img width="139" alt="Screen Shot 2022-12-19 at 11 07 55" src="https://user-images.githubusercontent.com/3948302/208335400-90aff191-8a72-4ede-aae5-082a1a9ed903.png">